### PR TITLE
Adding docker image + fix broken link

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y git cron
+RUN git clone https://github.com/PapillonApp/docs.git .
+RUN pip3 install -r requirements.txt
+EXPOSE 8000
+COPY update.sh /app/update.sh
+RUN chmod +x /app/update.sh
+RUN crontab -l | { cat; echo "0 * * * * /app/update.sh"; } | crontab -
+CMD ["cron", "-f"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+# Image docker pour la documentation de Papillon
+
+## Déploiement classique avec le Dockerfile
+```bash
+docker build -t papillondoc .
+docker run -d -p 8000:8000 --name PapillonDoc papillondoc
+```
+
+## Déploiement au sein d'un cluster swarm avec l'image créée précédemment'
+```bash
+docker stack deploy -c docker-compose.yml PapillonDoc
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+
+services:
+  mkdocs:
+    image: papillondoc
+    deploy:
+      mode: replicated
+      replicas: 2
+      placement:
+        constraints:
+          - node.role == worker
+    ports:
+      - "8000:8000"

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,4 @@
+mkdocs-material>=9.2.0b2
+mkdocs-git-committers-plugin-2>=1.1.2
+mkdocs-git-revision-date-localized-plugin>=1.2.0
+mkdocs-render-swagger-plugin>=0.1.1

--- a/docker/update.sh
+++ b/docker/update.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /app
+git pull origin master

--- a/docs/design/intro.md
+++ b/docs/design/intro.md
@@ -16,7 +16,7 @@ Pour faciliter la conception du design de l'application, nous vous recommandons 
 
 - [Papillon 🦋 - v6 (PUBLIC) :octicons-link-external-24:](https://www.figma.com/file/BBRs6LrDJvKs79JIDk1h6M/Papillon-%F0%9F%A6%8B---v6-(PUBLIC)?type=design&node-id=291%3A766&mode=design&t=Asx54o7vvJwd1T7m-1){target="_blank"}
 
-- [Charte graphique (PDF) :octicons-link-external-24:](https://cdn.tryon-lab.fr/Charte%20Graphique%20-%20Papillon%20(sept.%202023).pdf){target="_blank"}
+- [Charte graphique (PDF) :octicons-link-external-24:](https://cdn.getpapillon.xyz/files/Charte%20Graphique%20-%20Papillon%20(sept.%202023).pdf){target="_blank"}
 
 
 Ces fichiers contiennent les éléments visuels de l'application, tels que les couleurs, les typographies, les icônes et les composants. Ils sont mis à jour régulièrement pour refléter les dernières modifications apportées à l'application.


### PR DESCRIPTION
Adding Dockerfile, docker-compose.yml and README for deploying PapillonDoc in Docker, and updating link : cdn.tryon-lab.fr => cdn.getpapillon.xyz