### PR TITLE
:memo: (readme) remove netify status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Documentation de Papillon
 Vous pouvez contribuer à la documentation de Papillon via ce dépôt GitHub.
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/77ac80de-20da-47a1-9043-26fa306df471/deploy-status)](https://app.netlify.com/sites/papillon-docs/deploys)
-
 ## Ajouter des pages
 Le contenu du site est écrit en [**Markdown**](https://docs.github.com/fr/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) et se trouve dans `/docs`.
 


### PR DESCRIPTION
Reason : Now GitHub Pages